### PR TITLE
Replace Biobambam with Samtools' markdup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,8 @@ release 3.0.0
     - improve documentation
   - change installation method for dependencies in travis to use conda
     - add check for biobambam to also use cache
+  - replace biobambam's "bamstreamingmarkduplicates" with samtools' "markdup"
+    - still present in dev tests
 
 release 2.0.0
   - upgrade async to 2.4.1 from 2.1.4

--- a/lib/server/model.js
+++ b/lib/server/model.js
@@ -25,7 +25,6 @@ const pipeline = require('./pipeline.js');
 const config   = require('../config.js');
 
 const SAMTOOLS_COMMAND     = 'samtools';
-const BBB_MARKDUPS_COMMAND = 'bamstreamingmarkduplicates';
 const FREEBAYES_COMMAND    = 'freebayes';
 const DEFAULT_FORMAT       = 'BAM';
 
@@ -225,13 +224,6 @@ class RangerModel {
     return attrs;
   }
 
-  _bbbMarkDupsAttrs() {
-    var attrs = ['level=0','verbose=0','resetdupflag=1'];
-    attrs.push('tmpfile=' + config.tempFilePath());
-    attrs.push('M=/dev/null'); // Discard metrics data. Would default to STDERR.
-    return attrs;
-  }
-
   static fixReference(query) {
     assert(query);
     let options = config.provide();
@@ -296,12 +288,15 @@ class RangerModel {
     );
     merge.title = 'samtools merge';
 
+    // two '-', one to pipe in from stdin and one to pipe to stdout
+    attrs = ['markdup', '-', '-'];
     const markdup = child.spawn(
-      BBB_MARKDUPS_COMMAND,
-      this._bbbMarkDupsAttrs(),
+      SAMTOOLS_COMMAND,
+      attrs,
       {cwd: dir}
     );
-    markdup.title = BBB_MARKDUPS_COMMAND;
+    markdup.title = 'samtools markdup';
+
     delete query.region;
     delete query.directory;
     query.files = [];
@@ -311,7 +306,6 @@ class RangerModel {
       {cwd: dir}
     );
     view.title = 'samtools view (post-merge)';
-
     let processes = [merge, markdup, view];
     if (query.format === 'VCF') {
       this._scheduleVCF(query, processes, dir);


### PR DESCRIPTION
 - Remove bamstreamingmarkduplicates and function used to
   construct it
 - Replace its functionality with samtool's markdup utility,
   present in samtools 1.6 and up